### PR TITLE
Add pytest test for streamlit_app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 streamlit
+pytest

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1,0 +1,8 @@
+import runpy
+from pathlib import Path
+
+
+def test_import_streamlit_app():
+    """Ensure streamlit_app runs without raising exceptions when executed."""
+    path = Path(__file__).resolve().parents[1] / "streamlit_app.py"
+    runpy.run_path(str(path))


### PR DESCRIPTION
## Summary
- add simple test to run `streamlit_app` without import errors
- include pytest in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c1922d2848323a08b2e632e2fb3bc